### PR TITLE
Dispatch change event on selection change

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -192,6 +192,12 @@ This program is available under Apache License Version 2.0, available at https:/
               value: DEFAULT_VALUE
             },
 
+            htmlValue: {
+              type: String,
+              notify: true,
+              readOnly: true
+            },
+
             /**
              * When true, the user can not modify, nor copy the editor content.
              */
@@ -261,7 +267,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * HTML representation of the rich text editor content.
          * @type {string}
          */
-        get htmlValue() {
+        __updateHtmlValue() {
           const className = 'ql-editor';
           const editor = this.shadowRoot.querySelector(`.${className}`);
           let content = editor.innerHTML;
@@ -279,7 +285,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
           content = content.replace(/ class=""/g, '');
 
-          return content;
+          this._setHtmlValue(content);
         }
 
         __announceFormatting() {
@@ -316,9 +322,16 @@ This program is available under Apache License Version 2.0, available at https:/
           editor.firstElementChild.setAttribute('aria-multiline', 'true');
 
           this._editor.on('text-change', (delta, oldDelta, source) => {
-            this.__userInput = source === 'user';
-            this.value = JSON.stringify(this._editor.getContents().ops);
-            this.__userInput = false;
+            const timeout = 200;
+            this.__debounceSetValue = Polymer.Debouncer.debounce(
+              this.__debounceSetValue,
+              Polymer.Async.timeOut.after(timeout),
+              () => {
+                this.__userInput = source === 'user';
+                this.value = JSON.stringify(this._editor.getContents().ops);
+                this.__userInput = false;
+              }
+            );
           });
 
           this._editor.on('selection-change', this.__announceFormatting.bind(this));
@@ -475,6 +488,7 @@ This program is available under Apache License Version 2.0, available at https:/
           const delta = new Quill.imports.delta(parsedValue);
           // suppress text-change event to prevent infinite loop
           editor.setContents(delta, 'silent');
+          this.__updateHtmlValue();
         }
       }
 

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -255,7 +255,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
             _editor: {
               type: Object
-            }
+            },
+
+            /**
+             * Stores old value
+             */
+            __oldValue: String
           };
         }
 
@@ -264,6 +269,78 @@ This program is available under Apache License Version 2.0, available at https:/
             '_valueChanged(value, _editor)',
             '_disabledChanged(disabled, readonly, _editor)'
           ];
+        }
+
+        ready() {
+          super.ready();
+
+          const editor = this.shadowRoot.querySelector('[part="content"]');
+          const toolbar = this.shadowRoot.querySelector('[part="toolbar"]');
+
+          this._editor = new Quill(editor, {
+            modules: {
+              toolbar: toolbar
+            }
+          });
+
+          editor.firstElementChild.setAttribute('role', 'textbox');
+          editor.firstElementChild.setAttribute('aria-multiline', 'true');
+
+          this._editor.on('text-change', (delta, oldDelta, source) => {
+            const timeout = 200;
+            this.__debounceSetValue = Polymer.Debouncer.debounce(
+              this.__debounceSetValue,
+              Polymer.Async.timeOut.after(timeout),
+              () => {
+                this.__userInput = source === 'user';
+                this.value = JSON.stringify(this._editor.getContents().ops);
+                this.__userInput = false;
+              }
+            );
+          });
+
+          const editorContent = this.shadowRoot.querySelector('.ql-editor');
+          editorContent.addEventListener('blur', this.__emitChangeEvent.bind(this));
+
+          this._editor.on('selection-change', this.__announceFormatting.bind(this));
+
+          const buttons = this._toolbarButtons;
+
+          // Disable tabbing to all buttons but the first one
+          buttons.forEach((button, index) => index > 0 && button.setAttribute('tabindex', '-1'));
+
+          toolbar.addEventListener('keydown', e => {
+            // Use roving tab-index for the toolbar buttons
+            let index = buttons.indexOf(e.target);
+            buttons[index].setAttribute('tabindex', '-1');
+            if (e.keyCode === 39 && ++index === buttons.length) {
+              index = 0;
+            } else if (e.keyCode === 37 && --index === -1) {
+              index = buttons.length - 1;
+            }
+            buttons[index].removeAttribute('tabindex');
+            buttons[index].focus();
+
+            // Esc focuses the content
+            e.keyCode === 27 && this._editor.focus();
+          });
+
+          editor.addEventListener('keydown', e => {
+            // alt-f10 focuses a toolbar button
+            if (e.keyCode === 121 && e.altKey) {
+              toolbar.querySelector('button:not([tabindex])').focus();
+            }
+          });
+
+        }
+
+        __emitChangeEvent() {
+          this.__debounceSetValue && this.__debounceSetValue.flush();
+
+          if (this.__oldValue !== this.value) {
+            this.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: false}));
+            this.__oldValue = this.value;
+          }
         }
 
         __updateHtmlValue() {
@@ -303,66 +380,6 @@ This program is available under Apache License Version 2.0, available at https:/
               announcer.textContent = formatting;
             }
           );
-        }
-
-        ready() {
-          super.ready();
-
-          const editor = this.shadowRoot.querySelector('[part="content"]');
-          const toolbar = this.shadowRoot.querySelector('[part="toolbar"]');
-
-          this._editor = new Quill(editor, {
-            modules: {
-              toolbar: toolbar
-            }
-          });
-
-          editor.firstElementChild.setAttribute('role', 'textbox');
-          editor.firstElementChild.setAttribute('aria-multiline', 'true');
-
-          this._editor.on('text-change', (delta, oldDelta, source) => {
-            const timeout = 200;
-            this.__debounceSetValue = Polymer.Debouncer.debounce(
-              this.__debounceSetValue,
-              Polymer.Async.timeOut.after(timeout),
-              () => {
-                this.__userInput = source === 'user';
-                this.value = JSON.stringify(this._editor.getContents().ops);
-                this.__userInput = false;
-              }
-            );
-          });
-
-          this._editor.on('selection-change', this.__announceFormatting.bind(this));
-
-          const buttons = this._toolbarButtons;
-
-          // Disable tabbing to all buttons but the first one
-          buttons.forEach((button, index) => index > 0 && button.setAttribute('tabindex', '-1'));
-
-          toolbar.addEventListener('keydown', e => {
-            // Use roving tab-index for the toolbar buttons
-            let index = buttons.indexOf(e.target);
-            buttons[index].setAttribute('tabindex', '-1');
-            if (e.keyCode === 39 && ++index === buttons.length) {
-              index = 0;
-            } else if (e.keyCode === 37 && --index === -1) {
-              index = buttons.length - 1;
-            }
-            buttons[index].removeAttribute('tabindex');
-            buttons[index].focus();
-
-            // Esc focuses the content
-            e.keyCode === 27 && this._editor.focus();
-          });
-
-          editor.addEventListener('keydown', e => {
-            // alt-f10 focuses a toolbar button
-            if (e.keyCode === 121 && e.altKey) {
-              toolbar.querySelector('button:not([tabindex])').focus();
-            }
-          });
-
         }
 
         get _toolbarButtons() {
@@ -489,6 +506,12 @@ This program is available under Apache License Version 2.0, available at https:/
           editor.setContents(delta, 'silent');
           this.__updateHtmlValue();
         }
+
+        /**
+         * Fired when the user commits a value change.
+         *
+         * @event change
+         */
       }
 
       customElements.define(RichTextEditorElement.is, RichTextEditorElement);

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -477,6 +477,8 @@ This program is available under Apache License Version 2.0, available at https:/
           if (value === undefined && ! this.__oldValue || editor === undefined) {
             return;
           }
+
+          this.__updateHtmlValue();
           // prevent editor contents from being reset by user input
           if (this.__userInput) {
             return;
@@ -504,7 +506,6 @@ This program is available under Apache License Version 2.0, available at https:/
           const delta = new Quill.imports.delta(parsedValue);
           // suppress text-change event to prevent infinite loop
           editor.setContents(delta, 'silent');
-          this.__updateHtmlValue();
         }
 
         /**

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -192,6 +192,9 @@ This program is available under Apache License Version 2.0, available at https:/
               value: DEFAULT_VALUE
             },
 
+            /**
+             * HTML representation of the rich text editor content.
+             */
             htmlValue: {
               type: String,
               notify: true,
@@ -263,10 +266,6 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
-        /**
-         * HTML representation of the rich text editor content.
-         * @type {string}
-         */
         __updateHtmlValue() {
           const className = 'ql-editor';
           const editor = this.shadowRoot.querySelector(`.${className}`);

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -297,10 +297,15 @@ This program is available under Apache License Version 2.0, available at https:/
                 this.__userInput = false;
               }
             );
+            this.__wasBlurred && this.__emitChangeEvent();
+            this.__wasBlurred = false;
           });
 
           const editorContent = this.shadowRoot.querySelector('.ql-editor');
-          editorContent.addEventListener('blur', this.__emitChangeEvent.bind(this));
+          editorContent.addEventListener('blur', () => {
+            this.__wasBlurred = true;
+            this.__emitChangeEvent();
+          });
 
           this._editor.on('selection-change', this.__announceFormatting.bind(this));
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -277,10 +277,15 @@
       describe('htmlValue', () => {
         let el;
 
-        function setValueAndFormat(format, value = true) {
+        function setValueAndFormatLine(format, value = true) {
           rte.value = JSON.stringify([{insert: 'Foo'}]);
-          editor.setSelection(0, 3);
-          editor.format(format, value);
+          editor.formatLine(0, 1, format, value);
+          flushValueDebouncer();
+        }
+
+        function setValueAndFormatText(format, value = true) {
+          rte.value = JSON.stringify([{insert: 'Foo'}]);
+          editor.formatText(0, 3, format, value);
           flushValueDebouncer();
         }
 
@@ -307,82 +312,82 @@
         });
 
         it('should use <strong> tag for bold formatting', () => {
-          setValueAndFormat('bold');
+          setValueAndFormatText('bold');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('strong');
         });
 
         it('should use <em> tag for italic formatting', () => {
-          setValueAndFormat('italic');
+          setValueAndFormatText('italic');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('em');
         });
 
         it('should use <u> tag for underline formatting', () => {
-          setValueAndFormat('underline');
+          setValueAndFormatText('underline');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('u');
         });
 
         it('should use <s> tag for strike formatting', () => {
-          setValueAndFormat('strike');
+          setValueAndFormatText('strike');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('s');
         });
 
         it('should use <h1> tag for level 1 header', () => {
-          setValueAndFormat('header', 1);
+          setValueAndFormatLine('header', 1);
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('h1');
         });
 
         it('should use <h2> tag for level 2 header', () => {
-          setValueAndFormat('header', 2);
+          setValueAndFormatLine('header', 2);
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('h2');
         });
 
         it('should use <sub> tag for sub-script', () => {
-          setValueAndFormat('script', 'sub');
+          setValueAndFormatText('script', 'sub');
           el = getHtml(rte.htmlValue);
           expect(el.firstChild.localName).to.equal('sub');
         });
 
         it('should use <sup> tag for super-script', () => {
-          setValueAndFormat('script', 'super');
+          setValueAndFormatText('script', 'super');
           el = getHtml(rte.htmlValue);
           expect(el.firstChild.localName).to.equal('sup');
         });
 
         it('should use <ol> tag for ordered list', () => {
-          setValueAndFormat('list', 'ordered');
+          setValueAndFormatLine('list', 'ordered');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('ol');
           expect(el.firstChild.localName).to.equal('li');
         });
 
         it('should use <ul> tag for bullet list', () => {
-          setValueAndFormat('list', 'bullet');
+          setValueAndFormatLine('list', 'bullet');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('ul');
           expect(el.firstChild.localName).to.equal('li');
         });
 
         it('should use <blockquote> tag for quote', () => {
-          setValueAndFormat('blockquote');
+          setValueAndFormatLine('blockquote');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('blockquote');
         });
 
         it('should use <pre> tag for code block', () => {
-          setValueAndFormat('code-block');
+          setValueAndFormatLine('code-block');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('pre');
           expect(el.className).to.equal('');
         });
 
         it('should use inline styles for text alignment', () => {
-          setValueAndFormat('align', 'center');
+          setValueAndFormatLine('align', 'center');
           el = getHtml(rte.htmlValue);
           expect(el.style.textAlign).to.equal('center');
         });

--- a/test/basic.html
+++ b/test/basic.html
@@ -27,6 +27,8 @@
     describe('rich text editor', () => {
       'use strict';
 
+      const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
+
       let rte, editor;
 
       beforeEach(() => {
@@ -275,6 +277,13 @@
       describe('htmlValue', () => {
         let el;
 
+        function setValueAndFormat(format, value = true) {
+          rte.value = JSON.stringify([{insert: 'Foo'}]);
+          editor.setSelection(0, 3);
+          editor.format(format, value);
+          flushValueDebouncer();
+        }
+
         const getHtml = htmlValue => {
           const div = document.createElement('div');
           div.innerHTML = rte.htmlValue;
@@ -285,8 +294,9 @@
           expect(rte.htmlValue).to.equal('<p><br></p>');
         });
 
-        it('should be read only getter', () => {
-          expect(() => rte.htmlValue = '<h1>Hack</h1>').to.throw(TypeError);
+        it('should be read only property', () => {
+          rte.htmlValue = '<h1>Foo</h1>';
+          expect(rte.htmlValue).not.to.be.eql('<h1>Foo</h1>');
         });
 
         it('should use <p> tag to wrap inline text', () => {
@@ -297,82 +307,82 @@
         });
 
         it('should use <strong> tag for bold formatting', () => {
-          editor.format('bold', true);
+          setValueAndFormat('bold');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('strong');
         });
 
         it('should use <em> tag for italic formatting', () => {
-          editor.format('italic', true);
+          setValueAndFormat('italic');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('em');
         });
 
         it('should use <u> tag for underline formatting', () => {
-          editor.format('underline', true);
+          setValueAndFormat('underline');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('u');
         });
 
         it('should use <s> tag for strike formatting', () => {
-          editor.format('strike', true);
+          setValueAndFormat('strike');
           el = getHtml(rte.htmlValue).firstChild;
           expect(el.localName).to.equal('s');
         });
 
         it('should use <h1> tag for level 1 header', () => {
-          editor.format('header', 1);
+          setValueAndFormat('header', 1);
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('h1');
         });
 
         it('should use <h2> tag for level 2 header', () => {
-          editor.format('header', 2);
+          setValueAndFormat('header', 2);
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('h2');
         });
 
         it('should use <sub> tag for sub-script', () => {
-          editor.format('script', 'sub');
+          setValueAndFormat('script', 'sub');
           el = getHtml(rte.htmlValue);
           expect(el.firstChild.localName).to.equal('sub');
         });
 
         it('should use <sup> tag for super-script', () => {
-          editor.format('script', 'super');
+          setValueAndFormat('script', 'super');
           el = getHtml(rte.htmlValue);
           expect(el.firstChild.localName).to.equal('sup');
         });
 
         it('should use <ol> tag for ordered list', () => {
-          editor.format('list', 'ordered');
+          setValueAndFormat('list', 'ordered');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('ol');
           expect(el.firstChild.localName).to.equal('li');
         });
 
         it('should use <ul> tag for bullet list', () => {
-          editor.format('list', 'bullet');
+          setValueAndFormat('list', 'bullet');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('ul');
           expect(el.firstChild.localName).to.equal('li');
         });
 
         it('should use <blockquote> tag for quote', () => {
-          editor.format('blockquote', true);
+          setValueAndFormat('blockquote');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('blockquote');
         });
 
         it('should use <pre> tag for code block', () => {
-          editor.format('code-block', true);
+          setValueAndFormat('code-block');
           el = getHtml(rte.htmlValue);
           expect(el.localName).to.equal('pre');
           expect(el.className).to.equal('');
         });
 
         it('should use inline styles for text alignment', () => {
-          editor.format('align', 'center');
+          setValueAndFormat('align', 'center');
           el = getHtml(rte.htmlValue);
           expect(el.style.textAlign).to.equal('center');
         });

--- a/test/basic.html
+++ b/test/basic.html
@@ -312,6 +312,12 @@
           expect(rte.htmlValue).to.equal('<p><br></p>');
         });
 
+        it('should be updated from user input to Quill', () => {
+          editor.insertText(0, 'Foo', 'user');
+          flushValueDebouncer();
+          expect(rte.htmlValue).to.be.eql('<p>Foo</p>');
+        });
+
         it('should be read only property', () => {
           rte.htmlValue = '<h1>Foo</h1>';
           expect(rte.htmlValue).not.to.be.eql('<h1>Foo</h1>');

--- a/test/basic.html
+++ b/test/basic.html
@@ -205,6 +205,19 @@
 
           expect(spy.calledOnce).to.be.true;
         });
+
+        it('should dispatch change event after styling the content with toolbar', () => {
+          const spy = sinon.spy();
+          rte.addEventListener('change', spy);
+
+          // Emulate using the toolbar: removing focus from editor and applying styling after that.
+          rte.value = JSON.stringify([{insert: 'Foo'}]);
+          rte.shadowRoot.querySelector('.ql-editor').dispatchEvent(new CustomEvent('blur'));
+          rte._editor.formatText(0, 3, 'bold', true, 'user');
+
+          expect(rte.__wasBlurred).to.be.false;
+          expect(spy.calledOnce).to.be.true;
+        });
       });
 
       describe('value', () => {

--- a/test/basic.html
+++ b/test/basic.html
@@ -194,6 +194,19 @@
         });
       });
 
+      describe('change event', () => {
+        it('should dispatch change event on blur event when content was changed', () => {
+          const spy = sinon.spy();
+          rte.addEventListener('change', spy);
+
+          // Emulate setting the value from keyboard
+          rte._editor.setContents(new window.Quill.imports.delta([{insert: 'Foo'}]), 'user');
+          rte.shadowRoot.querySelector('.ql-editor').dispatchEvent(new CustomEvent('blur'));
+
+          expect(spy.calledOnce).to.be.true;
+        });
+      });
+
       describe('value', () => {
         it('by default should be stringified empty "delta" of the editor', done => {
           expect(rte.value).to.be.string;


### PR DESCRIPTION
Connects to #30

Add `debouncer` for setting `value`.
Switch from `htmlValue` getter to `readonly` property.
`htmlValue` property is now aligned with `value` and doesn't store pure formatting, only text with formatting / only text

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/39)
<!-- Reviewable:end -->