### PR TITLE
Ignore hidden buttons in roving tabindex

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -408,7 +408,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         get _toolbarButtons() {
-          return Array.from(this.shadowRoot.querySelectorAll('[part="toolbar"] button'));
+          return Array.from(this.shadowRoot.querySelectorAll('[part="toolbar"] button')).filter(btn => {
+            return btn.clientHeight > 0;
+          });
         }
 
         _clear() {


### PR DESCRIPTION
Some buttons could be hidden by a theme using `display: none` for example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/58)
<!-- Reviewable:end -->
