### PR TITLE
Implement interaction state for proper change event dispatching

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -121,6 +121,30 @@ This program is available under Apache License Version 2.0, available at https:/
       const Quill = window.Quill;
       const DEFAULT_VALUE = '[{"insert":"\\n"}]';
 
+      const HANDLERS = [
+        'bold',
+        'italic',
+        'underline',
+        'strike',
+        'header',
+        'script',
+        'list',
+        'align',
+        'blockquote',
+        'code-block'
+      ];
+
+      const MODE = {
+        USER: 'user',
+        SILENT: 'silent'
+      };
+
+      const STATE = {
+        DEFAULT: 0,
+        TOOLBAR_FOCUSED: 1,
+        TOOLBAR_CLICKED: 2
+      };
+
       /**
        * `<vaadin-rich-text-editor>` is a Web Component for rich text editing.
        * It provides a set of toolbar controls to apply formatting on the content,
@@ -277,7 +301,12 @@ This program is available under Apache License Version 2.0, available at https:/
             /**
              * Stores old value
              */
-            __oldValue: String
+            __oldValue: String,
+
+            __lastCommittedChange: {
+              type: String,
+              value: DEFAULT_VALUE
+            }
           };
         }
 
@@ -292,16 +321,19 @@ This program is available under Apache License Version 2.0, available at https:/
           super.ready();
 
           const editor = this.shadowRoot.querySelector('[part="content"]');
-          const toolbar = this.shadowRoot.querySelector('[part="toolbar"]');
+          const toolbarConfig = this._prepareToolbar();
+          const toolbar = toolbarConfig.container;
 
           this._editor = new Quill(editor, {
             modules: {
-              toolbar: toolbar
+              toolbar: toolbarConfig
             }
           });
 
-          editor.firstElementChild.setAttribute('role', 'textbox');
-          editor.firstElementChild.setAttribute('aria-multiline', 'true');
+          const editorContent = editor.querySelector('.ql-editor');
+
+          editorContent.setAttribute('role', 'textbox');
+          editorContent.setAttribute('aria-multiline', 'true');
 
           this._editor.on('text-change', (delta, oldDelta, source) => {
             const timeout = 200;
@@ -310,20 +342,31 @@ This program is available under Apache License Version 2.0, available at https:/
               Polymer.Async.timeOut.after(timeout),
               () => {
                 this.value = JSON.stringify(this._editor.getContents().ops);
-                this.__userInput = source === 'user';
               }
             );
-            this.__wasBlurred && this.__emitChangeEvent();
-            this.__wasBlurred = false;
           });
 
-          const editorContent = this.shadowRoot.querySelector('.ql-editor');
-          editorContent.addEventListener('blur', () => {
-            this.__wasBlurred = true;
-            this.__emitChangeEvent();
+          // mousedown happens before editor focusout
+          toolbar.addEventListener('mousedown', e => {
+            if (this._toolbarButtons.indexOf(e.composedPath()[0]) > -1) {
+              this._interactionState = STATE.TOOLBAR_FOCUSED;
+            }
           });
 
-          this.addEventListener('focusout', () => this.__wasBlurred = false);
+          editorContent.addEventListener('focusout', e => {
+            if (this._interactionState === STATE.TOOLBAR_FOCUSED) {
+              this._interactionState = STATE.DEFAULT;
+            } else {
+              this.__emitChangeEvent();
+            }
+          });
+
+          editorContent.addEventListener('focusin', e => {
+            // format changed, but no value changed happened
+            if (this._interactionState === STATE.TOOLBAR_CLICKED) {
+              this._interactionState = STATE.DEFAULT;
+            }
+          });
 
           this._editor.on('selection-change', this.__announceFormatting.bind(this));
 
@@ -350,19 +393,47 @@ This program is available under Apache License Version 2.0, available at https:/
 
           editor.addEventListener('keydown', e => {
             // alt-f10 focuses a toolbar button
-            if (e.keyCode === 121 && e.altKey) {
+            const altF10 = e.keyCode === 121 && e.altKey;
+            const shiftTab = e.keyCode === 9 && e.shiftKey;
+            if (altF10 || shiftTab) {
+              // native Shift + Tab is flaky in Safari because of shadow selection polyfill
+              e.preventDefault();
+              this._interactionState = STATE.TOOLBAR_FOCUSED;
               toolbar.querySelector('button:not([tabindex])').focus();
             }
           });
+        }
 
+        _prepareToolbar() {
+          const clean = Quill.imports['modules/toolbar'].DEFAULTS.handlers.clean;
+          const self = this;
+
+          const toolbar = {
+            container: this.shadowRoot.querySelector('[part="toolbar"]'),
+            handlers: {
+              clean: function() {
+                self._interactionState = STATE.TOOLBAR_CLICKED;
+                clean.call(this);
+              }
+            }
+          };
+
+          HANDLERS.forEach(handler => {
+            toolbar.handlers[handler] = value => {
+              this._interactionState = STATE.TOOLBAR_CLICKED;
+              this._editor.format(handler, value, MODE.user);
+            };
+          });
+
+          return toolbar;
         }
 
         __emitChangeEvent() {
           this.__debounceSetValue && this.__debounceSetValue.flush();
 
-          if (this.__userInput) {
+          if (this.__lastCommittedChange !== this.value) {
             this.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: false}));
-            this.__userInput = false;
+            this.__lastCommittedChange = this.value;
           }
         }
 
@@ -468,8 +539,8 @@ This program is available under Apache License Version 2.0, available at https:/
                 .retain(range.index)
                 .delete(range.length)
                 .insert({image})
-              , 'user');
-              this._editor.setSelection(range.index + 1, 'silent');
+              , MODE.user);
+              this._editor.setSelection(range.index + 1, MODE.silent);
               fileInput.value = '';
             };
             reader.readAsDataURL(fileInput.files[0]);
@@ -529,6 +600,11 @@ This program is available under Apache License Version 2.0, available at https:/
             editor.setContents(delta, 'silent');
           }
           this.__updateHtmlValue();
+
+          if (this._interactionState === STATE.TOOLBAR_CLICKED) {
+            this._interactionState = STATE.DEFAULT;
+            this.__emitChangeEvent();
+          }
         }
 
         /**

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -141,8 +141,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
       const STATE = {
         DEFAULT: 0,
-        TOOLBAR_FOCUSED: 1,
-        TOOLBAR_CLICKED: 2
+        FOCUSED: 1,
+        CLICKED: 2
       };
 
       /**
@@ -349,13 +349,13 @@ This program is available under Apache License Version 2.0, available at https:/
           // mousedown happens before editor focusout
           toolbar.addEventListener('mousedown', e => {
             if (this._toolbarButtons.indexOf(e.composedPath()[0]) > -1) {
-              this._interactionState = STATE.TOOLBAR_FOCUSED;
+              this._markToolbarFocused();
             }
           });
 
           editorContent.addEventListener('focusout', e => {
-            if (this._interactionState === STATE.TOOLBAR_FOCUSED) {
-              this._interactionState = STATE.DEFAULT;
+            if (this._toolbarState === STATE.FOCUSED) {
+              this._cleanToolbarState();
             } else {
               this.__emitChangeEvent();
             }
@@ -363,8 +363,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
           editorContent.addEventListener('focusin', e => {
             // format changed, but no value changed happened
-            if (this._interactionState === STATE.TOOLBAR_CLICKED) {
-              this._interactionState = STATE.DEFAULT;
+            if (this._toolbarState === STATE.CLICKED) {
+              this._cleanToolbarState();
             }
           });
 
@@ -398,7 +398,7 @@ This program is available under Apache License Version 2.0, available at https:/
             if (altF10 || shiftTab) {
               // native Shift + Tab is flaky in Safari because of shadow selection polyfill
               e.preventDefault();
-              this._interactionState = STATE.TOOLBAR_FOCUSED;
+              this._markToolbarFocused();
               toolbar.querySelector('button:not([tabindex])').focus();
             }
           });
@@ -406,13 +406,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _prepareToolbar() {
           const clean = Quill.imports['modules/toolbar'].DEFAULTS.handlers.clean;
-          const self = this;
+          const markToolbarClicked = this._markToolbarClicked.bind(this);
 
           const toolbar = {
             container: this.shadowRoot.querySelector('[part="toolbar"]'),
             handlers: {
               clean: function() {
-                self._interactionState = STATE.TOOLBAR_CLICKED;
+                markToolbarClicked();
                 clean.call(this);
               }
             }
@@ -420,12 +420,24 @@ This program is available under Apache License Version 2.0, available at https:/
 
           HANDLERS.forEach(handler => {
             toolbar.handlers[handler] = value => {
-              this._interactionState = STATE.TOOLBAR_CLICKED;
+              markToolbarClicked();
               this._editor.format(handler, value, MODE.user);
             };
           });
 
           return toolbar;
+        }
+
+        _markToolbarClicked() {
+          this._toolbarState = STATE.CLICKED;
+        }
+
+        _markToolbarFocused() {
+          this._toolbarState = STATE.FOCUSED;
+        }
+
+        _cleanToolbarState() {
+          this._toolbarState = STATE.DEFAULT;
         }
 
         __emitChangeEvent() {
@@ -540,6 +552,7 @@ This program is available under Apache License Version 2.0, available at https:/
                 .delete(range.length)
                 .insert({image})
               , MODE.user);
+              this._markToolbarClicked();
               this._editor.setSelection(range.index + 1, MODE.silent);
               fileInput.value = '';
             };
@@ -601,8 +614,8 @@ This program is available under Apache License Version 2.0, available at https:/
           }
           this.__updateHtmlValue();
 
-          if (this._interactionState === STATE.TOOLBAR_CLICKED) {
-            this._interactionState = STATE.DEFAULT;
+          if (this._toolbarState === STATE.CLICKED) {
+            this._cleanToolbarState();
             this.__emitChangeEvent();
           }
         }

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -134,7 +134,7 @@ This program is available under Apache License Version 2.0, available at https:/
         'code-block'
       ];
 
-      const MODE = {
+      const SOURCE = {
         USER: 'user',
         SILENT: 'silent'
       };
@@ -361,7 +361,7 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           });
 
-          editorContent.addEventListener('focusin', e => {
+          editorContent.addEventListener('focus', e => {
             // format changed, but no value changed happened
             if (this._toolbarState === STATE.CLICKED) {
               this._cleanToolbarState();
@@ -406,13 +406,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
         _prepareToolbar() {
           const clean = Quill.imports['modules/toolbar'].DEFAULTS.handlers.clean;
-          const markToolbarClicked = this._markToolbarClicked.bind(this);
+          const self = this;
 
           const toolbar = {
             container: this.shadowRoot.querySelector('[part="toolbar"]'),
             handlers: {
               clean: function() {
-                markToolbarClicked();
+                self._markToolbarClicked();
                 clean.call(this);
               }
             }
@@ -420,8 +420,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
           HANDLERS.forEach(handler => {
             toolbar.handlers[handler] = value => {
-              markToolbarClicked();
-              this._editor.format(handler, value, MODE.user);
+              this._markToolbarClicked();
+              this._editor.format(handler, value, SOURCE.user);
             };
           });
 
@@ -551,9 +551,9 @@ This program is available under Apache License Version 2.0, available at https:/
                 .retain(range.index)
                 .delete(range.length)
                 .insert({image})
-              , MODE.user);
+              , SOURCE.user);
               this._markToolbarClicked();
-              this._editor.setSelection(range.index + 1, MODE.silent);
+              this._editor.setSelection(range.index + 1, SOURCE.silent);
               fileInput.value = '';
             };
             reader.readAsDataURL(fileInput.files[0]);
@@ -617,6 +617,9 @@ This program is available under Apache License Version 2.0, available at https:/
           if (this._toolbarState === STATE.CLICKED) {
             this._cleanToolbarState();
             this.__emitChangeEvent();
+          } else if (!this._editor.hasFocus()) {
+            // value changed from outside
+            this.__lastCommittedChange = this.value;
           }
         }
 

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -128,6 +128,14 @@
           rte.shadowRoot.querySelector('[part="content"]').dispatchEvent(e);
         });
 
+        it('should focus a toolbar button on shift-tab combo', done => {
+          sinon.stub(buttons[0], 'focus', done);
+          const e = new CustomEvent('keydown', {bubbles: true});
+          e.keyCode = 9;
+          e.shiftKey = true;
+          rte.shadowRoot.querySelector('[part="content"]').dispatchEvent(e);
+        });
+
         it('should focus the editor on esc', done => {
           sinon.stub(editor, 'focus', done);
           const e = new CustomEvent('keydown', {bubbles: true});

--- a/test/basic.html
+++ b/test/basic.html
@@ -195,41 +195,80 @@
       });
 
       describe('change event', () => {
-        it('should dispatch change event on blur event when content was changed', () => {
+        var content;
+
+        const setContent = text => {
+          editor.setContents(new window.Quill.imports.delta([{insert: text}]), 'user');
+        };
+
+        beforeEach(() => {
+          content = rte.shadowRoot.querySelector('.ql-editor');
+        });
+
+        it('should dispatch change event on focusout event when content was changed', () => {
           const spy = sinon.spy();
           rte.addEventListener('change', spy);
 
           // Emulate setting the value from keyboard
-          editor.setContents(new window.Quill.imports.delta([{insert: 'Foo'}]), 'user');
-          rte.shadowRoot.querySelector('.ql-editor').dispatchEvent(new CustomEvent('blur'));
+          setContent('Foo');
+          content.dispatchEvent(new CustomEvent('focusout'));
 
-          expect(spy.calledOnce).to.be.true;
+          expect(spy).to.be.calledOnce;
         });
 
-        it('should dispatch change event after styling the content with toolbar', () => {
-          const spy = sinon.spy();
-          rte.addEventListener('change', spy);
-
-          // Emulate using the toolbar: removing focus from editor and applying styling after that.
+        it('should dispatch change event after styling the content with toolbar', done => {
           rte.value = JSON.stringify([{insert: 'Foo'}]);
-          rte.shadowRoot.querySelector('.ql-editor').dispatchEvent(new CustomEvent('blur'));
-          editor.formatText(0, 3, 'bold', true, 'user');
 
-          expect(rte.__wasBlurred).to.be.false;
-          expect(spy.calledOnce).to.be.true;
+          rte.addEventListener('change', () => {
+            expect(rte.value).to.equal('[{"attributes":{"bold":true},"insert":"Foo"},{"insert":"\\n"}]');
+            done();
+          });
+
+          // Emulate using the toolbar: selecting text and clicking a bold button.
+          editor.focus();
+          editor.setSelection(0, 3);
+          const btn = rte.shadowRoot.querySelector('[part="bold-button"]');
+          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.click();
         });
 
-        it('should not be dispatched on first text-change event after blurring the rte', () => {
+        it('should dispatch change event after clearing the formatting with toolbar', done => {
+          const text = JSON.stringify([{attributes: {bold: true}, insert: 'Foo\n'}]);
+          rte.value = text;
+
+          rte.addEventListener('change', () => {
+            expect(rte.value).to.equal(JSON.stringify([{insert: 'Foo\n'}]));
+            done();
+          });
+
+          // Emulate using the toolbar: selecting text and clicking a clear button.
+          editor.focus();
+          editor.setSelection(0, 3);
+          const btn = rte.shadowRoot.querySelector('[part="clean-button"]');
+          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.click();
+        });
+
+        it('should not be dispatched when text remains unchanged after leaving rte', () => {
           const spy = sinon.spy();
           rte.addEventListener('change', spy);
 
-          // Emulate typing to the editor, focusing smth outside the editor and then typing again.
-          editor.setContents(new window.Quill.imports.delta([{insert: 'Foo'}]), 'user');
-          rte.shadowRoot.querySelector('.ql-editor').dispatchEvent(new CustomEvent('blur'));
-          rte.dispatchEvent(new CustomEvent('focusout'));
-          editor.setContents(new window.Quill.imports.delta([{insert: 'Foo Bar'}]), 'user');
+          setContent('Foo');
+          content.dispatchEvent(new CustomEvent('focusout'));
+          editor.focus();
 
-          expect(spy.calledOnce).to.be.true;
+          // Emulate adding the formatting, removing it back and then moving focus out
+          editor.setSelection(0, 3);
+          const btn = rte.shadowRoot.querySelector('[part="bold-button"]');
+          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.click();
+
+          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.click();
+
+          content.dispatchEvent(new CustomEvent('focusout'));
+
+          expect(spy).to.be.calledOnce;
         });
       });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -231,10 +231,22 @@
           rte.addEventListener('change', spy);
 
           // Emulate setting the value from keyboard
+          editor.focus();
           setContent('Foo');
           content.dispatchEvent(new CustomEvent('focusout'));
 
           expect(spy).to.be.calledOnce;
+        });
+
+        it('should not dispatch change event on focusout when value set from outside', () => {
+          const spy = sinon.spy();
+          rte.addEventListener('change', spy);
+
+          rte.value = JSON.stringify([{insert: 'Foo\n'}]);
+          editor.focus();
+          content.dispatchEvent(new CustomEvent('focusout'));
+
+          expect(spy).to.not.be.called;
         });
 
         it('should dispatch change event after styling the content with toolbar', done => {
@@ -248,9 +260,33 @@
           // Emulate using the toolbar: selecting text and clicking a bold button.
           editor.focus();
           editor.setSelection(0, 3);
+
           const btn = rte.shadowRoot.querySelector('[part="bold-button"]');
-          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+          const evt = new CustomEvent('focusout');
+          evt.relatedTarget = btn;
+          content.dispatchEvent(evt);
           btn.click();
+
+          flushValueDebouncer();
+        });
+
+        it('should not dispatch change event if no styling changed after toolbar click', () => {
+          const spy = sinon.spy();
+          rte.addEventListener('change', spy);
+          rte.value = JSON.stringify([{insert: 'Foo'}]);
+
+          // Emulate using the toolbar: clicking a bold button with no text selected
+          editor.focus();
+          editor.setSelection(0, 0);
+
+          const btn = rte.shadowRoot.querySelector('[part="bold-button"]');
+          btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
+          btn.click();
+          content.dispatchEvent(new CustomEvent('focus'));
+          flushValueDebouncer();
+
+          expect(spy).to.not.be.called;
         });
 
         it('should dispatch change event after clearing the formatting with toolbar', done => {
@@ -266,30 +302,30 @@
           editor.focus();
           editor.setSelection(0, 3);
           const btn = rte.shadowRoot.querySelector('[part="clean-button"]');
-          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
           btn.click();
+          flushValueDebouncer();
         });
 
         it('should not be dispatched when text remains unchanged after leaving rte', () => {
           const spy = sinon.spy();
           rte.addEventListener('change', spy);
 
-          setContent('Foo');
-          content.dispatchEvent(new CustomEvent('focusout'));
+          rte.value = JSON.stringify([{insert: 'Foo\n'}]);
           editor.focus();
 
           // Emulate adding the formatting, removing it back and then moving focus out
           editor.setSelection(0, 3);
           const btn = rte.shadowRoot.querySelector('[part="bold-button"]');
-          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
           btn.click();
 
-          btn.dispatchEvent(new MouseEvent('mousedown'));
+          btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
           btn.click();
 
           content.dispatchEvent(new CustomEvent('focusout'));
 
-          expect(spy).to.be.calledOnce;
+          expect(spy).to.not.be.called;
         });
       });
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -191,6 +191,27 @@
             // trigger mock image upload
             fileInput.dispatchEvent(new Event('change'));
           });
+
+          it('should mark image button as clicked for subsequent change event', done => {
+            const markClickedSpy = sinon.spy(rte, '_markToolbarClicked');
+
+            const fileInput = rte.shadowRoot.querySelector('input[type="file"]');
+            fileInput.__proto__ = HTMLElement.prototype;
+            delete fileInput.files;
+
+            editor.focus();
+
+            const img = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+            fileInput.files = [createImage(img, 'image/gif')];
+
+            rte.addEventListener('value-changed', () => {
+              expect(markClickedSpy).to.be.calledOnce;
+              done();
+            });
+
+            // trigger mock image upload
+            fileInput.dispatchEvent(new Event('change'));
+          });
         });
       });
 


### PR DESCRIPTION
Fixes #55 

The current change event workflow after this PR:

1. focus editor, type text, select text, click toolbar -> change event with all formatting
2. focus editor, type text, move focus out -> change event
3. editor not focused, click toolbar (line formatting, e.g. h1 or blockquote) -> change event

Previously, in the 1st case there used to be 2 change events in non-Chrome browsers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/80)
<!-- Reviewable:end -->
