### PR TITLE
Fix shift-tab key combo to work properly in the list items

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "iron-component-page": "^3.0.0",
     "iron-demo-helpers": "^2.0.0",
+    "iron-test-helpers": "^2.0.0",
     "webcomponentsjs": "^1.0.0",
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^2.0.0"

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -144,6 +144,8 @@ This program is available under Apache License Version 2.0, available at https:/
         CLICKED: 2
       };
 
+      const TAB_KEY = 9;
+
       /**
        * `<vaadin-rich-text-editor>` is a Web Component for rich text editing.
        * It provides a set of toolbar controls to apply formatting on the content,
@@ -323,7 +325,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
           const editor = this.shadowRoot.querySelector('[part="content"]');
           const toolbarConfig = this._prepareToolbar();
-          const toolbar = toolbarConfig.container;
+          this._toolbar = toolbarConfig.container;
+
+          this._addToolbarListeners();
 
           this._editor = new Quill(editor, {
             modules: {
@@ -332,6 +336,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
 
           this.__patchToolbar();
+          this.__patchKeyboard();
 
           const editorContent = editor.querySelector('.ql-editor');
 
@@ -347,13 +352,6 @@ This program is available under Apache License Version 2.0, available at https:/
                 this.value = JSON.stringify(this._editor.getContents().ops);
               }
             );
-          });
-
-          // mousedown happens before editor focusout
-          toolbar.addEventListener('mousedown', e => {
-            if (this._toolbarButtons.indexOf(e.composedPath()[0]) > -1) {
-              this._markToolbarFocused();
-            }
           });
 
           editorContent.addEventListener('focusout', e => {
@@ -372,39 +370,6 @@ This program is available under Apache License Version 2.0, available at https:/
           });
 
           this._editor.on('selection-change', this.__announceFormatting.bind(this));
-
-          const buttons = this._toolbarButtons;
-
-          // Disable tabbing to all buttons but the first one
-          buttons.forEach((button, index) => index > 0 && button.setAttribute('tabindex', '-1'));
-
-          toolbar.addEventListener('keydown', e => {
-            // Use roving tab-index for the toolbar buttons
-            let index = buttons.indexOf(e.target);
-            buttons[index].setAttribute('tabindex', '-1');
-            if (e.keyCode === 39 && ++index === buttons.length) {
-              index = 0;
-            } else if (e.keyCode === 37 && --index === -1) {
-              index = buttons.length - 1;
-            }
-            buttons[index].removeAttribute('tabindex');
-            buttons[index].focus();
-
-            // Esc focuses the content
-            e.keyCode === 27 && this._editor.focus();
-          });
-
-          editor.addEventListener('keydown', e => {
-            // alt-f10 focuses a toolbar button
-            const altF10 = e.keyCode === 121 && e.altKey;
-            const shiftTab = e.keyCode === 9 && e.shiftKey;
-            if (altF10 || shiftTab) {
-              // native Shift + Tab is flaky in Safari because of shadow selection polyfill
-              e.preventDefault();
-              this._markToolbarFocused();
-              toolbar.querySelector('button:not([tabindex])').focus();
-            }
-          });
         }
 
         _prepareToolbar() {
@@ -431,6 +396,37 @@ This program is available under Apache License Version 2.0, available at https:/
           return toolbar;
         }
 
+        _addToolbarListeners() {
+          const buttons = this._toolbarButtons;
+          const toolbar = this._toolbar;
+
+          // Disable tabbing to all buttons but the first one
+          buttons.forEach((button, index) => index > 0 && button.setAttribute('tabindex', '-1'));
+
+          toolbar.addEventListener('keydown', e => {
+            // Use roving tab-index for the toolbar buttons
+            let index = buttons.indexOf(e.target);
+            buttons[index].setAttribute('tabindex', '-1');
+            if (e.keyCode === 39 && ++index === buttons.length) {
+              index = 0;
+            } else if (e.keyCode === 37 && --index === -1) {
+              index = buttons.length - 1;
+            }
+            buttons[index].removeAttribute('tabindex');
+            buttons[index].focus();
+
+            // Esc focuses the content
+            e.keyCode === 27 && this._editor.focus();
+          });
+
+          // mousedown happens before editor focusout
+          toolbar.addEventListener('mousedown', e => {
+            if (buttons.indexOf(e.composedPath()[0]) > -1) {
+              this._markToolbarFocused();
+            }
+          });
+        }
+
         _markToolbarClicked() {
           this._toolbarState = STATE.CLICKED;
         }
@@ -444,7 +440,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         __patchToolbar() {
-          const toolbar = this._editor.theme.modules.toolbar;
+          const toolbar = this._editor.getModule('toolbar');
           const update = toolbar.update;
 
           toolbar.update = function(range) {
@@ -459,6 +455,28 @@ This program is available under Apache License Version 2.0, available at https:/
               }
             });
           };
+        }
+
+        __patchKeyboard() {
+          const focusToolbar = () => {
+            this._editor.blur();
+            this._markToolbarFocused();
+            this._toolbar.querySelector('button:not([tabindex])').focus();
+          };
+
+          const keyboard = this._editor.getModule('keyboard');
+          const bindings = keyboard.bindings[TAB_KEY];
+
+          // exclude Quill shift-tab bindings, except for code block,
+          // as some of those are breaking when on a newline in the list
+          // https://github.com/vaadin/vaadin-rich-text-editor/issues/67
+          const originalBindings = bindings.filter(b => !b.shiftKey || b.format && b.format['code-block']);
+          const moveFocusBinding = {key: TAB_KEY, shiftKey: true, handler: focusToolbar};
+
+          keyboard.bindings[TAB_KEY] = [...originalBindings, moveFocusBinding];
+
+          // alt-f10 focuses a toolbar button
+          keyboard.addBinding({key: 121, altKey: true, handler: focusToolbar});
         }
 
         __emitChangeEvent() {

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -8,6 +8,7 @@
     "expect": false,
     "gemini": false,
     "sinon": false,
+    "MockInteractions": false,
     "createImage": false
   }
 }

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -6,6 +6,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../test-fixture/test-fixture.html">
+  <script src="../../iron-test-helpers/mock-interactions.js"></script>
   <link rel="import" href="../vaadin-rich-text-editor.html">
 </head>
 
@@ -23,6 +24,8 @@
       const flushFormatAnnouncer = () => {
         rte.__debounceAnnounceFormatting && rte.__debounceAnnounceFormatting.flush();
       };
+
+      const flushValueDebouncer = () => rte.__debounceSetValue && rte.__debounceSetValue.flush();
 
       let rte, content, buttons, announcer, editor;
 
@@ -98,21 +101,18 @@
 
         it('should focus the next button on right-arrow', done => {
           sinon.stub(buttons[0], 'focus', done);
-          const e = new CustomEvent('keydown', {bubbles: true});
-          e.keyCode = 39;
+          const e = MockInteractions.keyboardEventFor('keydown', 39);
           buttons[buttons.length - 1].dispatchEvent(e);
         });
 
         it('should focus the previous button on left-arrow', done => {
           sinon.stub(buttons[buttons.length - 1], 'focus', done);
-          const e = new CustomEvent('keydown', {bubbles: true});
-          e.keyCode = 37;
+          const e = MockInteractions.keyboardEventFor('keydown', 37);
           buttons[0].dispatchEvent(e);
         });
 
         it('should change the tabbable button on arrow navigation', () => {
-          const e = new CustomEvent('keydown', {bubbles: true});
-          e.keyCode = 39;
+          const e = MockInteractions.keyboardEventFor('keydown', 39);
           buttons[0].dispatchEvent(e);
           expect(buttons[0].getAttribute('tabindex')).to.equal('-1');
           expect(buttons[1].getAttribute('tabindex')).not.to.be.ok;
@@ -122,18 +122,16 @@
         // the combo to work. The toolbar is still accessible with the tab key normally.
         it('should focus a toolbar button on meta-f10 combo', done => {
           sinon.stub(buttons[0], 'focus', done);
-          const e = new CustomEvent('keydown', {bubbles: true});
-          e.keyCode = 121;
-          e.altKey = true;
-          rte.shadowRoot.querySelector('[part="content"]').dispatchEvent(e);
+          editor.focus();
+          const e = MockInteractions.keyboardEventFor('keydown', 121, ['alt']);
+          content.dispatchEvent(e);
         });
 
         it('should focus a toolbar button on shift-tab combo', done => {
           sinon.stub(buttons[0], 'focus', done);
-          const e = new CustomEvent('keydown', {bubbles: true});
-          e.keyCode = 9;
-          e.shiftKey = true;
-          rte.shadowRoot.querySelector('[part="content"]').dispatchEvent(e);
+          editor.focus();
+          const e = MockInteractions.keyboardEventFor('keydown', 9, ['shift']);
+          content.dispatchEvent(e);
         });
 
         it('should focus the editor on esc', done => {
@@ -143,6 +141,26 @@
           buttons[0].dispatchEvent(e);
         });
 
+        it('should blur the content on shift-tab in the list item', () => {
+          const spy = sinon.spy(content, 'blur');
+          rte.value = '[{"attributes":{"list":"bullet"},"insert":"\\n"}]';
+          editor.focus();
+          editor.setSelection(0, 0);
+          const e = MockInteractions.keyboardEventFor('keydown', 9, ['shift']);
+          content.dispatchEvent(e);
+          expect(spy).to.be.calledOnce;
+        });
+
+        it('should change indentation and prevent shift-tab keydown in the code block', () => {
+          rte.value = '[{"insert":"  foo"},{"attributes":{"code-block":true},"insert":"\\n"}]';
+          editor.focus();
+          editor.setSelection(2, 0);
+          const e = MockInteractions.keyboardEventFor('keydown', 9, ['shift']);
+          content.dispatchEvent(e);
+          flushValueDebouncer();
+          expect(rte.value).to.equal('[{"insert":"foo"},{"attributes":{"code-block":true},"insert":"\\n"}]');
+          expect(e.defaultPrevented).to.be.true;
+        });
       });
 
     });


### PR DESCRIPTION
Fixes #67 

Note: tests are not in the best shape due to fact they are related to the focus, and I did not want to bring the full polyfill we use in Grid at this point.

There are actually 2 issues here:

1. Calling `_editor.blur()` before focusing fixes Safari issue, where focus returns back to the editor

2. Whitelisting of the Quill <kbd>Shift</kbd>+<kbd>Tab</kbd> bindings fixes another issue, when focus is not moving at all, when placed on the newline in the list. Binding causing this to happen is apparently this one:
https://github.com/quilljs/quill/blob/1.3.6/modules/keyboard.js#L157

In case if we need multi levels list feature (and therefore, same keyboard combo for decreasing list indentation level), we might need to revisit this and find out the better workaround.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/89)
<!-- Reviewable:end -->
