### PR TITLE
Fix incorrect link button test in Safari

### DIFF
--- a/test/basic.html
+++ b/test/basic.html
@@ -266,8 +266,6 @@
 
           describe('dialog', () => {
             it('should not open the confirm dialog when the editor does not have focus', () => {
-              editor.focus();
-              editor.blur();
               btn.click();
               expect(dialog.opened).to.be.false;
             });


### PR DESCRIPTION
Fixes the failing test in Safari on master, apparently timing issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/91)
<!-- Reviewable:end -->
