### PR TITLE
Fix change event when focusing toolbar on shift-tab

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -533,8 +533,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
         __patchKeyboard() {
           const focusToolbar = () => {
-            this._editor.blur();
             this._markToolbarFocused();
+            this._editor.blur();
             this._toolbar.querySelector('button:not([tabindex])').focus();
           };
 

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -134,6 +134,17 @@
           content.dispatchEvent(e);
         });
 
+        it('should mark toolbar as focused before blurring content on shift-tab', done => {
+          const spy = sinon.spy(rte, '_markToolbarFocused');
+          sinon.stub(editor, 'blur', () => {
+            expect(spy).to.be.calledOnce;
+            done();
+          });
+          editor.focus();
+          const e = MockInteractions.keyboardEventFor('keydown', 9, ['shift']);
+          content.dispatchEvent(e);
+        });
+
         it('should focus the editor on esc', done => {
           sinon.stub(editor, 'focus', done);
           const e = new CustomEvent('keydown', {bubbles: true});


### PR DESCRIPTION
Regression from #89 caused `change` event to be incorrectly dispatched.
Due to complexity of the focus-related tests, have to again rely on internal methods sequence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/94)
<!-- Reviewable:end -->
