### PR TITLE
Revert editor blur causing selection to be lost

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -624,7 +624,6 @@ This program is available under Apache License Version 2.0, available at https:/
         __patchKeyboard() {
           const focusToolbar = () => {
             this._markToolbarFocused();
-            this._editor.blur();
             this._toolbar.querySelector('button:not([tabindex])').focus();
           };
 

--- a/test/accessibility.html
+++ b/test/accessibility.html
@@ -162,14 +162,16 @@
           expect(result).to.be.false; // dispatchEvent returns false when preventDefault is called
         });
 
-        it('should blur the content on shift-tab in the list item', () => {
-          const spy = sinon.spy(content, 'blur');
-          rte.value = '[{"attributes":{"list":"bullet"},"insert":"\\n"}]';
+        it('should preserve the text selection on shift-tab', done => {
+          sinon.stub(buttons[0], 'focus', () => {
+            expect(editor.getSelection()).to.deep.equal({index: 0, length: 2});
+            done();
+          });
+          rte.value = '[{"attributes":{"list":"bullet"},"insert":"Foo\\n"}]';
           editor.focus();
-          editor.setSelection(0, 0);
+          editor.setSelection(0, 2);
           const e = MockInteractions.keyboardEventFor('keydown', 9, ['shift']);
           content.dispatchEvent(e);
-          expect(spy).to.be.calledOnce;
         });
 
         it('should change indentation and prevent shift-tab keydown in the code block', () => {


### PR DESCRIPTION
Fixes #96

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/97)
<!-- Reviewable:end -->
