### PR TITLE
Fix compact theme

### DIFF
--- a/theme/lumo/vaadin-rich-text-editor-styles.html
+++ b/theme/lumo/vaadin-rich-text-editor-styles.html
@@ -200,7 +200,7 @@
       /* Compact */
 
       :host([theme~="compact"]) {
-        height: calc(var(--lumo-size-m) * 6);
+        min-height: calc(var(--lumo-size-m) * 6);
       }
 
       :host([theme~="compact"]) [part="toolbar"] {


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-rich-text-editor/issues/106

Fix compact theme to use `min-height` on `host` instead of `height`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-rich-text-editor/108)
<!-- Reviewable:end -->
