### PR TITLE
Fix change event

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -675,9 +675,14 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         __emitChangeEvent() {
-          this.__debounceSetValue && this.__debounceSetValue.flush();
+          let lastCommittedChange = this.__lastCommittedChange;
 
-          if (this.__lastCommittedChange !== this.value) {
+          if (this.__debounceSetValue && this.__debounceSetValue.isActive()) {
+            lastCommittedChange = this.value;
+            this.__debounceSetValue.flush();
+          }
+
+          if (lastCommittedChange !== this.value) {
             this.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: false}));
             this.__lastCommittedChange = this.value;
           }

--- a/test/basic.html
+++ b/test/basic.html
@@ -443,6 +443,9 @@
           // Emulate setting the value from keyboard
           editor.focus();
           setContent('Foo');
+          // Setting selection range to null in Quill
+          // Needed for proper hasFocus() check
+          content.blur();
           content.dispatchEvent(new CustomEvent('focusout'));
 
           expect(spy).to.be.calledOnce;
@@ -454,6 +457,7 @@
 
           rte.value = JSON.stringify([{insert: 'Foo\n'}]);
           editor.focus();
+          content.blur();
           content.dispatchEvent(new CustomEvent('focusout'));
 
           expect(spy).to.not.be.called;
@@ -475,6 +479,7 @@
           btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
           const evt = new CustomEvent('focusout');
           evt.relatedTarget = btn;
+          content.blur();
           content.dispatchEvent(evt);
           btn.click();
 
@@ -533,6 +538,7 @@
           btn.dispatchEvent(new MouseEvent('mousedown', {bubbles: true}));
           btn.click();
 
+          content.blur();
           content.dispatchEvent(new CustomEvent('focusout'));
 
           expect(spy).to.not.be.called;


### PR DESCRIPTION
**Description of the issue:**
On `text-change` we are setting the `__debounceSetValue` which will change the value after [200ms](https://github.com/vaadin/vaadin-rich-text-editor/blob/6861a998a0c9db7329ce69897c6e7cb6a9a6fd90/src/vaadin-rich-text-editor.html#L476). On `focusout` we are comparing `__lastCommittedChange` and current `value` and if they are not the same we are dispatching the `change` event. 

But in case when the `focusout` will occur before 200ms timeout, debouncer will be [flushed](https://github.com/vaadin/vaadin-rich-text-editor/blob/6861a998a0c9db7329ce69897c6e7cb6a9a6fd90/src/vaadin-rich-text-editor.html#L678) and on the focus check [`hasFocus()`](https://github.com/vaadin/vaadin-rich-text-editor/blob/6861a998a0c9db7329ce69897c6e7cb6a9a6fd90/src/vaadin-rich-text-editor.html#L958) in the `_valueChanged` observer it will set the `__lastCommittedChange` to be the current value. It will lead to not dispatching `change` event.

The test are now using [`blur`](https://github.com/quilljs/quill/blob/5b28603337f3a7a2b651f94cffc9754b61eaeec7/core/quill.js#L137) before `focusout` in order to properly check Quill's [`hasFocus`](https://github.com/quilljs/quill/blob/5b28603337f3a7a2b651f94cffc9754b61eaeec7/core/quill.js#L319)