### PR TITLE
refactor: only run license checker when needed

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -420,6 +420,19 @@ This program is available under Apache License Version 2.0, available at https:/
         /**
          * @protected
          */
+        static _finalizeClass() {
+          super._finalizeClass();
+
+          const devModeCallback = window.Vaadin.developmentModeCallback;
+          const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
+          if (typeof licenseChecker === 'function') {
+            licenseChecker(RichTextEditorElement);
+          }
+        }
+
+        /**
+         * @protected
+         */
         attributeChangedCallback(prop, oldVal, newVal) {
           super.attributeChangedCallback(prop, oldVal, newVal);
           // Needed until Edge has CSS Custom Properties (present in Edge Preview)
@@ -977,12 +990,6 @@ This program is available under Apache License Version 2.0, available at https:/
        * @namespace Vaadin
        */
       window.Vaadin.RichTextEditorElement = RichTextEditorElement;
-
-      const devModeCallback = window.Vaadin.developmentModeCallback;
-      const licenseChecker = devModeCallback && devModeCallback['vaadin-license-checker'];
-      if (typeof licenseChecker === 'function') {
-        licenseChecker(RichTextEditorElement);
-      }
     })();
   </script>
 </dom-module>


### PR DESCRIPTION
Connected to vaadin/components-team-tasks#492

This PR makes sure the license checker is only called when the component is created.
The static `_finalizeClass` method is needed to ensure we call it [once per class](https://github.com/Polymer/polymer/blob/f6ccc9d1bdc81e934e21bf27b3dba517b5840fd4/lib/mixins/properties-mixin.js#L138-L147).