### PR TITLE
feat: prepare for TS defs generation [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,27 @@
+export interface RichTextEditorI18n {
+  undo: string;
+  redo: string;
+  bold: string;
+  italic: string;
+  underline: string;
+  strike: string;
+  h1: string;
+  h2: string;
+  h3: string;
+  subscript: string;
+  superscript: string;
+  listOrdered: string;
+  listBullet: string;
+  alignLeft: string;
+  alignCenter: string;
+  alignRight: string;
+  image: string;
+  link: string;
+  blockquote: string;
+  codeBlock: string;
+  clean: string;
+  linkDialogTitle: string;
+  ok: string;
+  cancel: string;
+  remove: string;
+}

--- a/bower.json
+++ b/bower.json
@@ -29,11 +29,11 @@
   ],
   "dependencies": {
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.3.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0",
-    "vaadin-button": "vaadin/vaadin-button#^2.3.0",
-    "vaadin-confirm-dialog": "vaadin/vaadin-confirm-dialog#^1.2.0",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.6.0",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1",
+    "vaadin-button": "vaadin/vaadin-button#^2.4.0-alpha1",
+    "vaadin-confirm-dialog": "vaadin/vaadin-confirm-dialog#^1.3.0-alpha1",
+    "vaadin-text-field": "vaadin/vaadin-text-field#^2.7.0-alpha1",
     "vaadin-license-checker": "vaadin/license-checker#^2.1.0",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2"

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,19 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "src/vaadin-rich-text-editor-content-styles.js",
+    "src/vaadin-rich-text-editor-icons.js",
+    "src/vaadin-rich-text-editor-styles.js",
+    "src/vaadin-rich-text-editor-toolbar-styles.js",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*",
+    "vendor/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "RichTextEditorI18n"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'vaadin-rich-text-editor.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "vendor",
     "theme"

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -312,7 +312,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * HTML representation of the rich text editor content.
-             * @type {string}
              */
             htmlValue: {
               type: String,

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -302,6 +302,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * ```
              *
              * See also https://github.com/quilljs/delta for detailed documentation.
+             * @type {string}
              */
             value: {
               type: String,
@@ -311,6 +312,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * HTML representation of the rich text editor content.
+             * @type {string}
              */
             htmlValue: {
               type: String,
@@ -320,6 +322,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * When true, the user can not modify, nor copy the editor content.
+             * @type {boolean}
              */
             disabled: {
               type: Boolean,
@@ -329,6 +332,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * When true, the user can not modify the editor content, but can copy it.
+             * @type {boolean}
              */
             readonly: {
               type: Boolean,
@@ -340,10 +344,11 @@ This program is available under Apache License Version 2.0, available at https:/
              * An object used to localize this component. The properties are used
              * e.g. as the tooltips for the editor toolbar buttons.
              *
+             * @type {!RichTextEditorI18n}
              * @default {English/US}
              */
             i18n: {
-              type: Array,
+              type: Object,
               value: () => {
                 return {
                   undo: 'undo',
@@ -375,34 +380,41 @@ This program is available under Apache License Version 2.0, available at https:/
               }
             },
 
+            /** @private */
             _editor: {
               type: Object
             },
 
             /**
              * Stores old value
+             * @private
              */
             __oldValue: String,
 
+            /** @private */
             __lastCommittedChange: {
               type: String,
               value: ''
             },
 
+            /** @private */
             _linkEditing: {
               type: Boolean
             },
 
+            /** @private */
             _linkRange: {
               type: Object,
               value: null
             },
 
+            /** @private */
             _linkIndex: {
               type: Number,
               value: null
             },
 
+            /** @private */
             _linkUrl: {
               type: String,
               value: ''
@@ -417,9 +429,7 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
-        /**
-         * @protected
-         */
+        /** @protected */
         static _finalizeClass() {
           super._finalizeClass();
 
@@ -431,6 +441,9 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         /**
+         * @param {string} prop
+         * @param {?string} oldVal
+         * @param {?string} newVal
          * @protected
          */
         attributeChangedCallback(prop, oldVal, newVal) {
@@ -456,6 +469,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         __setDirection(dir) {
           // Needed for proper `ql-align` class to be set and activate the toolbar align button
           const alignAttributor = Quill.import('attributors/class/align');
@@ -475,6 +489,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._editor.getModule('toolbar').update(this._editor.getSelection());
         }
 
+        /** @protected */
         ready() {
           super.ready();
 
@@ -536,6 +551,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._editor.on('selection-change', this.__announceFormatting.bind(this));
         }
 
+        /** @private */
         _prepareToolbar() {
           const clean = Quill.imports['modules/toolbar'].DEFAULTS.handlers.clean;
           const self = this;
@@ -560,6 +576,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return toolbar;
         }
 
+        /** @private */
         _addToolbarListeners() {
           const buttons = this._toolbarButtons;
           const toolbar = this._toolbar;
@@ -596,18 +613,22 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         _markToolbarClicked() {
           this._toolbarState = STATE.CLICKED;
         }
 
+        /** @private */
         _markToolbarFocused() {
           this._toolbarState = STATE.FOCUSED;
         }
 
+        /** @private */
         _cleanToolbarState() {
           this._toolbarState = STATE.DEFAULT;
         }
 
+        /** @private */
         __createFakeFocusTarget() {
           const isRTL = document.documentElement.getAttribute('dir') == 'rtl';
           const elem = document.createElement('textarea');
@@ -624,6 +645,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return elem;
         }
 
+        /** @private */
         __patchFirefoxFocus() {
           // in Firefox 63 with native Shadow DOM, when moving focus out of
           // contenteditable and back again within same shadow root, cursor
@@ -667,6 +689,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         __patchToolbar() {
           const toolbar = this._editor.getModule('toolbar');
           const update = toolbar.update;
@@ -688,6 +711,7 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
+        /** @private */
         __patchKeyboard() {
           const focusToolbar = () => {
             this._markToolbarFocused();
@@ -709,6 +733,7 @@ This program is available under Apache License Version 2.0, available at https:/
           keyboard.addBinding({key: 121, altKey: true, handler: focusToolbar});
         }
 
+        /** @private */
         __emitChangeEvent() {
           let lastCommittedChange = this.__lastCommittedChange;
 
@@ -723,6 +748,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _onLinkClick() {
           const range = this._editor.getSelection();
           if (range) {
@@ -739,6 +765,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _applyLink(link) {
           if (link) {
             this._markToolbarClicked();
@@ -748,6 +775,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._closeLinkDialog();
         }
 
+        /** @private */
         _insertLink(link, position) {
           if (link) {
             this._markToolbarClicked();
@@ -757,12 +785,14 @@ This program is available under Apache License Version 2.0, available at https:/
           this._closeLinkDialog();
         }
 
+        /** @private */
         _updateLink(link, range) {
           this._markToolbarClicked();
           this._editor.formatText(range, 'link', link, SOURCE.USER);
           this._closeLinkDialog();
         }
 
+        /** @private */
         _removeLink() {
           this._markToolbarClicked();
           if (this._linkRange != null) {
@@ -771,6 +801,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._closeLinkDialog();
         }
 
+        /** @private */
         _closeLinkDialog() {
           this._linkEditing = false;
           this._linkUrl = '';
@@ -778,6 +809,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._linkRange = null;
         }
 
+        /** @private */
         _onLinkEditConfirm() {
           if (this._linkIndex != null) {
             this._insertLink(this._linkUrl, this._linkIndex);
@@ -788,16 +820,19 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _onLinkEditCancel() {
           this._closeLinkDialog();
           this._editor.focus();
         }
 
+        /** @private */
         _onLinkEditRemove() {
           this._removeLink();
           this._closeLinkDialog();
         }
 
+        /** @private */
         _onLinkKeydown(e) {
           if (e.keyCode === 13) {
             e.preventDefault();
@@ -806,6 +841,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         __updateHtmlValue() {
           const className = 'ql-editor';
           const editor = this.shadowRoot.querySelector(`.${className}`);
@@ -827,7 +863,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._setHtmlValue(content);
         }
 
-        /*
+        /**
          * Sets content represented by HTML snippet into the editor.
          * The snippet is interpreted by [Quill's Clipboard matchers](https://quilljs.com/docs/modules/clipboard/#matchers),
          * which may not produce the exactly input HTML.
@@ -835,12 +871,14 @@ This program is available under Apache License Version 2.0, available at https:/
          * **NOTE:** Improper handling of HTML can lead to cross site scripting (XSS) and failure to sanitize
          * properly is both notoriously error-prone and a leading cause of web vulnerabilities.
          * This method is aptly named to ensure the developer has taken the necessary precautions.
+         * @param {string} htmlValue
          */
         dangerouslySetHtmlValue(htmlValue) {
           const deltaFromHtml = this._editor.clipboard.convert(htmlValue);
           this._editor.setContents(deltaFromHtml, SOURCE.USER);
         }
 
+        /** @private */
         __announceFormatting() {
           const timeout = 200;
 
@@ -859,29 +897,34 @@ This program is available under Apache License Version 2.0, available at https:/
           );
         }
 
+        /** @private */
         get _toolbarButtons() {
           return Array.from(this.shadowRoot.querySelectorAll('[part="toolbar"] button')).filter(btn => {
             return btn.clientHeight > 0;
           });
         }
 
+        /** @private */
         _clear() {
           this._editor.deleteText(0, this._editor.getLength(), SOURCE.SILENT);
           this.__updateHtmlValue();
         }
 
+        /** @private */
         _undo(e) {
           e.preventDefault();
           this._editor.history.undo();
           this._editor.focus();
         }
 
+        /** @private */
         _redo(e) {
           e.preventDefault();
           this._editor.history.redo();
           this._editor.focus();
         }
 
+        /** @private */
         _toggleToolbarDisabled(disable) {
           const buttons = this._toolbarButtons;
           if (disable) {
@@ -891,6 +934,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _onImageTouchEnd(e) {
           // Cancel the event to avoid the following click event
           e.preventDefault();
@@ -901,15 +945,18 @@ This program is available under Apache License Version 2.0, available at https:/
           this._onImageClick();
         }
 
+        /** @private */
         __resetMouseCanceller() {
           Polymer.Gestures.resetMouseCanceller();
         }
 
+        /** @private */
         _onImageClick() {
           this.$.fileInput.value = '';
           this.$.fileInput.click();
         }
 
+        /** @private */
         _uploadImage(e) {
           const fileInput = e.target;
           // NOTE: copied from https://github.com/quilljs/quill/blob/1.3.6/themes/base.js#L128
@@ -932,6 +979,7 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _disabledChanged(disabled, readonly, editor) {
           if (disabled === undefined || readonly === undefined || editor === undefined) {
             return;
@@ -954,6 +1002,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.__oldDisabled = disabled;
         }
 
+        /** @private */
         _valueChanged(value, editor) {
           if (editor === undefined) {
             return;


### PR DESCRIPTION
Fixes #135 

Generated TS definitions looks like this:

```ts

import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {timeOut} from '@polymer/polymer/lib/utils/async.js';

import {Debouncer} from '@polymer/polymer/lib/utils/debounce.js';

import {resetMouseCanceller} from '@polymer/polymer/lib/utils/gestures.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class RichTextEditorElement extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {
  value: string;
  readonly htmlValue: string;
  disabled: boolean;
  readonly: boolean;
  i18n: RichTextEditorI18n;
  static _finalizeClass(): void;
  ready(): void;
  attributeChangedCallback(prop: string, oldVal: string|null, newVal: string|null): void;
  dangerouslySetHtmlValue(htmlValue: string): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-rich-text-editor": RichTextEditorElement;
  }
}

export {RichTextEditorElement};

import {RichTextEditorI18n} from '../@types/interfaces';
```