### PR TITLE
Update value in read-only state on API call

### DIFF
--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -198,7 +198,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
       const SOURCE = {
         USER: 'user',
-        SILENT: 'silent'
+        SILENT: 'silent',
+        API : 'api'
       };
 
       const STATE = {
@@ -874,7 +875,7 @@ This program is available under Apache License Version 2.0, available at https:/
          */
         dangerouslySetHtmlValue(htmlValue) {
           const deltaFromHtml = this._editor.clipboard.convert(htmlValue);
-          this._editor.setContents(deltaFromHtml, SOURCE.USER);
+          this._editor.setContents(deltaFromHtml, SOURCE.API);
         }
 
         /** @private */

--- a/src/vaadin-rich-text-editor.html
+++ b/src/vaadin-rich-text-editor.html
@@ -197,9 +197,9 @@ This program is available under Apache License Version 2.0, available at https:/
       ];
 
       const SOURCE = {
+        API: 'api',
         USER: 'user',
-        SILENT: 'silent',
-        API : 'api'
+        SILENT: 'silent'
       };
 
       const STATE = {

--- a/test/basic.html
+++ b/test/basic.html
@@ -862,7 +862,7 @@
         });
 
         it('should update value on API call', () => {
-          rte.readonly = true;         
+          rte.readonly = true;
           rte.dangerouslySetHtmlValue('<h3><i>Foo</i>Bar</h3>');
           flushValueDebouncer();
           const delta = '[{"attributes":{"italic":true},"insert":"Foo"},{"insert":"Bar"},{"attributes":{"header":3},"insert":"\\n"}]';

--- a/test/basic.html
+++ b/test/basic.html
@@ -861,6 +861,16 @@
           expect(rte.hasAttribute('readonly')).to.be.true;
         });
 
+        it('should update value on API call', () => {
+          rte.readonly = true;         
+          rte.dangerouslySetHtmlValue('<h3><i>Foo</i>Bar</h3>');
+          flushValueDebouncer();
+          const delta = '[{"attributes":{"italic":true},"insert":"Foo"},{"insert":"Bar"},{"attributes":{"header":3},"insert":"\\n"}]';
+          expect(rte.value).to.equal(delta);
+          // Quill is converting the italic font to use appropriate tag
+          expect(rte.htmlValue).to.equal('<h3><em>Foo</em>Bar</h3>');
+        });
+
         it('should invoke the editor methods', () => {
           const spy = sinon.spy(editor, 'enable');
           rte.readonly = true;


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-rich-text-editor-flow/issues/91

There are 3 sources for an event `USER`, `API`, `SILENT`. A `dangerouslySetHtmlValue` is called on server-side only from the API call https://github.com/vaadin/vaadin-rich-text-editor-flow/blob/24f359ce6d9f498f8bf31db19720792dde8a4036/vaadin-rich-text-editor-flow/src/main/java/com/vaadin/flow/component/richtexteditor/RichTextEditor.java#L199, so the correct woul be to use `API` instead of `USER`,

